### PR TITLE
Depend on the Pagerfanta library instead of the Symfony bundle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,7 +32,7 @@
     "symfony/twig-bundle": "^4.3",
     "symfony/validator": "^4.3",
     "symfony/yaml": "^4.3",
-    "white-october/pagerfanta-bundle": "^1.2",
+    "pagerfanta/pagerfanta": "^2.0",
     "phpoffice/phpspreadsheet": "^1.7",
     "intervention/image": "^2.5"
   },


### PR DESCRIPTION
It looks like your bundle isn't depending explicitly on the now abandoned `WhiteOctoberPagerfantaBundle`, but uses the `Pagerfanta` library directly.  So this pull request changes the dependency from the bundle to the library.

Note, this could be considered a breaking change for consumers if they are expecting the bundle to be installed by depending on this bundle.  If the expectation is to install the Symfony integration bundle when installing this bundle, then you could install my `BabDevPagerfantaBundle` (which is the recommended replacement of the original bundle), but [there are breaking changes involved](https://github.com/BabDev/PagerfantaBundle/blob/2.x/UPGRADE-2.0.md) in that upgrade.